### PR TITLE
Fix placeholder issues.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lqa-boss-react",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "private": true,
   "type": "module",
   "engines": {
@@ -40,7 +40,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "lint": "npx tsc --noEmit --strict && echo 'TypeScript check passed'",
-    "test:unit": "node --test tests/unit/normalizedText.test.js tests/unit/saveHandler.test.js tests/unit/placeholderDisplay.test.js",
+    "test:unit": "node --test tests/unit/normalizedText.test.js tests/unit/saveHandler.test.js tests/unit/placeholderDisplay.test.js tests/unit/placeholderMapping.test.js",
     "test:ui": "npm run test:ui:start",
     "test:ui:start": "vite --port 3000 & echo $! > .vite.pid && wait-on http://localhost:3000 && npm run test:ui:run; EXIT_CODE=$?; kill $(cat .vite.pid) 2>/dev/null; rm -f .vite.pid; exit $EXIT_CODE",
     "test:ui:run": "node --test tests/ui/app.test.js tests/ui/editor.test.js",

--- a/src/components/NormalizedTextEditor.tsx
+++ b/src/components/NormalizedTextEditor.tsx
@@ -32,6 +32,7 @@ let globalPlaceholderDescriptions: { [key: string]: PlaceholderDescription } | u
 
 interface NormalizedTextEditorProps {
   normalizedContent: NormalizedItem[]
+  sourceContent?: NormalizedItem[]
   onChange: (normalizedContent: NormalizedItem[]) => void
   onFocus?: () => void
   isActive?: boolean
@@ -41,6 +42,7 @@ interface NormalizedTextEditorProps {
 
 const NormalizedTextEditor = forwardRef<NormalizedTextEditorRef, NormalizedTextEditorProps>(({
   normalizedContent,
+  sourceContent,
   onChange,
   onFocus,
   isActive,
@@ -299,9 +301,9 @@ const NormalizedTextEditor = forwardRef<NormalizedTextEditorRef, NormalizedTextE
         <PlainTextPastePlugin />
         <ArrowNavigationPlugin />
         <KeyboardShortcutPlugin />
-        <InitializePlugin normalizedContent={normalizedContent} />
-        <DragDropPlugin />
-        <EditorRefPlugin editorRef={editorRef} />
+        <InitializePlugin normalizedContent={normalizedContent} sourceContent={sourceContent} />
+        <DragDropPlugin sourceContent={sourceContent} />
+        <EditorRefPlugin editorRef={editorRef} sourceContent={sourceContent} />
       </Box>
     </LexicalComposer>
   )

--- a/src/components/TextSegmentEditor.tsx
+++ b/src/components/TextSegmentEditor.tsx
@@ -760,6 +760,7 @@ const TextSegmentEditor: React.FC<TextSegmentEditorProps> = ({
                       normalizedEditorRefs.current[tu.guid] = ref
                     }}
                     normalizedContent={tu.ntgt || []}
+                    sourceContent={tu.nsrc}
                     onChange={(newNtgt) => handleNormalizedChange(tu.guid, newNtgt)}
                     isActive={isActive}
                     placeholderDescriptions={placeholderDescriptions}

--- a/src/components/editor/nodes/PlaceholderNode.tsx
+++ b/src/components/editor/nodes/PlaceholderNode.tsx
@@ -126,21 +126,13 @@ export class PlaceholderNode extends DecoratorNode<React.ReactNode> {
   }
 
   getTextContent(): string {
-    // Extract the number from the placeholder value and add 1 for 1-based indexing
-    const match = this.__placeholder.v.match(/\{(\d+)\}/)
-    if (match) {
-      const num = parseInt(match[1], 10) + 1
-      return `{${num}}`
-    }
-    // Fallback to show index if pattern doesn't match
+    // Display position-based index + 1 (for 1-based numbering)
     return `{${this.__index + 1}}`
   }
 
   decorate(): React.ReactNode {
-    // Extract the number from placeholder value and add 1 for 1-based display
-    // This shows which placeholder from the job.json it corresponds to
-    const match = this.__placeholder.v.match(/\{(\d+)\}/)
-    const displayValue = match ? (parseInt(match[1], 10) + 1).toString() : (this.__index + 1).toString()
+    // Display position-based index + 1 (for 1-based numbering)
+    const displayValue = (this.__index + 1).toString()
     // Return wrapped in span - plain primitives don't work correctly with Lexical
     return <span>{displayValue}</span>
   }

--- a/src/components/editor/plugins/DragDropPlugin.tsx
+++ b/src/components/editor/plugins/DragDropPlugin.tsx
@@ -10,11 +10,15 @@ import {
   LexicalNode,
   TextNode
 } from 'lexical'
-import { NormalizedPlaceholder } from '../../../types'
+import { NormalizedItem, NormalizedPlaceholder } from '../../../types'
 import { $createPlaceholderNode, setAllowPlaceholderRemoval } from '../nodes/PlaceholderNode'
 
+interface DragDropPluginProps {
+  sourceContent?: NormalizedItem[]
+}
+
 // Plugin to handle drag and drop
-export function DragDropPlugin(): null {
+export function DragDropPlugin({ sourceContent }: DragDropPluginProps): null {
   const [editor] = useLexicalComposerContext()
 
   useEffect(() => {
@@ -334,7 +338,7 @@ export function DragDropPlugin(): null {
         removeDragIndicator()
       }
     }
-  }, [editor])
+  }, [editor, sourceContent])
 
   return null
 }

--- a/src/components/editor/plugins/EditorRefPlugin.tsx
+++ b/src/components/editor/plugins/EditorRefPlugin.tsx
@@ -11,7 +11,10 @@ export interface NormalizedTextEditorRef {
 }
 
 // Plugin to expose editor methods via ref
-export function EditorRefPlugin({ editorRef }: { editorRef: React.RefObject<NormalizedTextEditorRef | null> }): null {
+export function EditorRefPlugin({ editorRef, sourceContent }: {
+  editorRef: React.RefObject<NormalizedTextEditorRef | null>,
+  sourceContent?: NormalizedItem[]
+}): null {
   const [editor] = useLexicalComposerContext()
 
   React.useImperativeHandle(editorRef, () => ({
@@ -28,8 +31,20 @@ export function EditorRefPlugin({ editorRef }: { editorRef: React.RefObject<Norm
 
         let paragraph = $createParagraphNode()
 
-        // Track placeholder index (1-based)
-        let placeholderIndex = 1
+        // Build a list of source placeholders with their positions
+        const sourcePlaceholders: Array<{ item: NormalizedItem; index: number }> = []
+        if (sourceContent) {
+          let sourceIndex = 0
+          sourceContent.forEach(item => {
+            if (typeof item !== 'string') {
+              sourcePlaceholders.push({ item, index: sourceIndex })
+              sourceIndex++
+            }
+          })
+        }
+
+        // Track current position for fallback (0-based)
+        let currentPosition = 0
 
         content.forEach((item) => {
           if (typeof item === 'string') {
@@ -46,8 +61,24 @@ export function EditorRefPlugin({ editorRef }: { editorRef: React.RefObject<Norm
               }
             })
           } else {
-            paragraph.append($createPlaceholderNode(item, placeholderIndex))
-            placeholderIndex++
+            // Find the matching source placeholder
+            let index = currentPosition
+
+            if (sourceContent && sourcePlaceholders.length > 0) {
+              // For handling duplicates, find and remove the first matching item
+              const matchIndex = sourcePlaceholders.findIndex(sp =>
+                typeof sp.item !== 'string' &&
+                sp.item.v === item.v &&
+                sp.item.t === item.t
+              )
+              if (matchIndex !== -1) {
+                index = sourcePlaceholders[matchIndex].index
+                sourcePlaceholders.splice(matchIndex, 1)
+              }
+            }
+
+            paragraph.append($createPlaceholderNode(item, index))
+            currentPosition++
           }
         })
 
@@ -55,7 +86,7 @@ export function EditorRefPlugin({ editorRef }: { editorRef: React.RefObject<Norm
         root.append(paragraph)
       }, { tag: 'force-update' })
     }
-  }), [editor])
+  }), [editor, sourceContent])
 
   return null
 }

--- a/src/components/editor/plugins/InitializePlugin.tsx
+++ b/src/components/editor/plugins/InitializePlugin.tsx
@@ -15,9 +15,10 @@ import { normalizedArraysEqual } from '../../../utils/normalizedComparison'
 // Plugin to initialize editor with normalized content
 interface InitializePluginProps {
   normalizedContent: NormalizedItem[]
+  sourceContent?: NormalizedItem[]
 }
 
-export function InitializePlugin({ normalizedContent }: InitializePluginProps): null {
+export function InitializePlugin({ normalizedContent, sourceContent }: InitializePluginProps): null {
   const [editor] = useLexicalComposerContext()
   const isInitializedRef = useRef(false)
   const lastExternalContentRef = useRef<NormalizedItem[]>([])
@@ -86,8 +87,20 @@ export function InitializePlugin({ normalizedContent }: InitializePluginProps): 
 
         let paragraph = $createParagraphNode()
 
-        // Track placeholder index (1-based)
-        let placeholderIndex = 1
+        // Build a list of source placeholders with their positions
+        const sourcePlaceholders: Array<{ item: NormalizedItem; index: number }> = []
+        if (sourceContent) {
+          let sourceIndex = 0
+          sourceContent.forEach(item => {
+            if (typeof item !== 'string') {
+              sourcePlaceholders.push({ item, index: sourceIndex })
+              sourceIndex++
+            }
+          })
+        }
+
+        // Track current position for fallback (0-based)
+        let currentPosition = 0
 
         normalizedContent.forEach((item) => {
           if (typeof item === 'string') {
@@ -104,8 +117,44 @@ export function InitializePlugin({ normalizedContent }: InitializePluginProps): 
               }
             })
           } else {
-            paragraph.append($createPlaceholderNode(item, placeholderIndex))
-            placeholderIndex++
+            // Find the matching source placeholder
+            let index = currentPosition
+
+            if (sourceContent && sourcePlaceholders.length > 0) {
+              // First, try to find exact match including all properties
+              const exactMatch = sourcePlaceholders.find(sp =>
+                typeof sp.item !== 'string' &&
+                sp.item.v === item.v &&
+                sp.item.t === item.t
+              )
+
+              if (exactMatch) {
+                index = exactMatch.index
+              } else {
+                // If no exact match, try matching just by value
+                const valueMatch = sourcePlaceholders.find(sp =>
+                  typeof sp.item !== 'string' && sp.item.v === item.v
+                )
+                if (valueMatch) {
+                  index = valueMatch.index
+                }
+              }
+
+              // For handling duplicates, remove the matched item from future matches
+              // This ensures first occurrence in translation maps to first in source, etc.
+              const matchIndex = sourcePlaceholders.findIndex(sp =>
+                typeof sp.item !== 'string' &&
+                sp.item.v === item.v &&
+                sp.item.t === item.t
+              )
+              if (matchIndex !== -1) {
+                index = sourcePlaceholders[matchIndex].index
+                sourcePlaceholders.splice(matchIndex, 1)
+              }
+            }
+
+            paragraph.append($createPlaceholderNode(item, index))
+            currentPosition++
           }
         })
 
@@ -116,7 +165,7 @@ export function InitializePlugin({ normalizedContent }: InitializePluginProps): 
         isInitializedRef.current = true
       }, { tag: 'content-update' })
     }
-  }, [editor, normalizedContent])
+  }, [editor, normalizedContent, sourceContent])
 
   return null
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -111,7 +111,7 @@ const router = createBrowserRouter([
     element: <PathRedirect />,
   },
 ], {
-  basename: "/lqa-boss"
+  basename: "/"
 })
 
 const root = createRoot(document.getElementById('root')!)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -111,7 +111,7 @@ const router = createBrowserRouter([
     element: <PathRedirect />,
   },
 ], {
-  basename: "/"
+  basename: "/lqa-boss"
 })
 
 const root = createRoot(document.getElementById('root')!)

--- a/tests/unit/placeholderMapping.test.js
+++ b/tests/unit/placeholderMapping.test.js
@@ -1,0 +1,396 @@
+import { test, describe } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+/**
+ * Simulates the placeholder mapping logic from InitializePlugin
+ * Maps translation placeholders to their corresponding source positions
+ */
+function mapTranslationPlaceholdersToSource(sourceItems, translationItems) {
+  // Build a list of source placeholders with their positions
+  const sourcePlaceholders = [];
+  let sourceIndex = 0;
+  sourceItems.forEach(item => {
+    if (typeof item !== 'string') {
+      sourcePlaceholders.push({ item, index: sourceIndex });
+      sourceIndex++;
+    }
+  });
+
+  // Map translation placeholders
+  const mappedIndices = [];
+  let currentPosition = 0;
+
+  translationItems.forEach(item => {
+    if (typeof item !== 'string') {
+      // Find the matching source placeholder
+      let index = currentPosition;
+
+      if (sourcePlaceholders.length > 0) {
+        // For handling duplicates, find and remove the first matching item
+        const matchIndex = sourcePlaceholders.findIndex(sp =>
+          sp.item.v === item.v &&
+          sp.item.t === item.t
+        );
+
+        if (matchIndex !== -1) {
+          index = sourcePlaceholders[matchIndex].index;
+          sourcePlaceholders.splice(matchIndex, 1);
+        }
+      }
+
+      mappedIndices.push(index);
+      currentPosition++;
+    }
+  });
+
+  return mappedIndices;
+}
+
+/**
+ * Converts 0-based indices to 1-based display numbers
+ */
+function getDisplayNumbers(indices) {
+  return indices.map(i => i + 1);
+}
+
+describe('Placeholder Mapping Logic', () => {
+  test('source placeholders use position-based numbering', () => {
+    const source = [
+      'Text before ',
+      { v: '{0}', t: 'x' },
+      ' middle ',
+      { v: '{1}', t: 'x' },
+      ' end'
+    ];
+
+    // Extract source placeholder indices
+    const indices = [];
+    let index = 0;
+    source.forEach(item => {
+      if (typeof item !== 'string') {
+        indices.push(index);
+        index++;
+      }
+    });
+
+    assert.deepEqual(indices, [0, 1]);
+    assert.deepEqual(getDisplayNumbers(indices), [1, 2]);
+  });
+
+  test('translation placeholders map to source positions', () => {
+    const source = [
+      { v: '{0}', t: 'x', s: 'hours' },
+      { v: '{1}', t: 'x', s: 'from city' },
+      { v: '{2}', t: 'x', s: 'to city' }
+    ];
+
+    // Translation reorders them: {1}, {2}, {0}
+    const translation = [
+      { v: '{1}', t: 'x', s: 'from city' },
+      { v: '{2}', t: 'x', s: 'to city' },
+      { v: '{0}', t: 'x', s: 'hours' }
+    ];
+
+    const indices = mapTranslationPlaceholdersToSource(source, translation);
+    assert.deepEqual(indices, [1, 2, 0]);
+    assert.deepEqual(getDisplayNumbers(indices), [2, 3, 1]);
+  });
+
+  test('handles placeholders without numeric values in v field', () => {
+    const source = [
+      { v: '<b>', t: 'bx' },
+      { v: '<i>', t: 'bx' },
+      { v: '</b>', t: 'ex' },
+      { v: '</i>', t: 'ex' }
+    ];
+
+    // Translation reorders tags
+    const translation = [
+      { v: '<i>', t: 'bx' },
+      { v: '<b>', t: 'bx' },
+      { v: '</b>', t: 'ex' },
+      { v: '</i>', t: 'ex' }
+    ];
+
+    const indices = mapTranslationPlaceholdersToSource(source, translation);
+    // <i> is at position 1, <b> at 0, </b> at 2, </i> at 3
+    assert.deepEqual(indices, [1, 0, 2, 3]);
+    assert.deepEqual(getDisplayNumbers(indices), [2, 1, 3, 4]);
+  });
+
+  test('handles duplicate placeholders correctly', () => {
+    const source = [
+      { v: '<b>', t: 'bx' },  // First bold open - index 0
+      { v: '</b>', t: 'ex' }, // First bold close - index 1
+      { v: '<b>', t: 'bx' },  // Second bold open - index 2
+      { v: '</b>', t: 'ex' }  // Second bold close - index 3
+    ];
+
+    const translation = [
+      { v: '<b>', t: 'bx' },  // Should map to first <b> (index 0)
+      { v: '<b>', t: 'bx' },  // Should map to second <b> (index 2)
+      { v: '</b>', t: 'ex' }, // Should map to first </b> (index 1)
+      { v: '</b>', t: 'ex' }  // Should map to second </b> (index 3)
+    ];
+
+    const indices = mapTranslationPlaceholdersToSource(source, translation);
+    assert.deepEqual(indices, [0, 2, 1, 3]);
+    assert.deepEqual(getDisplayNumbers(indices), [1, 3, 2, 4]);
+  });
+
+  test('handles mixed placeholder types', () => {
+    const source = [
+      { v: '{0}', t: 'x' },
+      { v: '<b>', t: 'bx' },
+      { v: '{1}', t: 'x' },
+      { v: '</b>', t: 'ex' },
+      { v: '<i>', t: 'bx' },
+      { v: '</i>', t: 'ex' }
+    ];
+
+    const translation = [
+      { v: '<b>', t: 'bx' },
+      { v: '<i>', t: 'bx' },
+      { v: '{1}', t: 'x' },
+      { v: '</i>', t: 'ex' },
+      { v: '</b>', t: 'ex' },
+      { v: '{0}', t: 'x' }
+    ];
+
+    const indices = mapTranslationPlaceholdersToSource(source, translation);
+    // <b> at 1, <i> at 4, {1} at 2, </i> at 5, </b> at 3, {0} at 0
+    assert.deepEqual(indices, [1, 4, 2, 5, 3, 0]);
+    assert.deepEqual(getDisplayNumbers(indices), [2, 5, 3, 6, 4, 1]);
+  });
+
+  test('handles missing placeholders in translation', () => {
+    const source = [
+      { v: '{0}', t: 'x' },
+      { v: '{1}', t: 'x' },
+      { v: '{2}', t: 'x' }
+    ];
+
+    // Translation missing {1}
+    const translation = [
+      { v: '{2}', t: 'x' },
+      { v: '{0}', t: 'x' }
+    ];
+
+    const indices = mapTranslationPlaceholdersToSource(source, translation);
+    assert.deepEqual(indices, [2, 0]);
+    assert.deepEqual(getDisplayNumbers(indices), [3, 1]);
+  });
+
+  test('handles extra placeholders in translation', () => {
+    const source = [
+      { v: '{0}', t: 'x' },
+      { v: '{1}', t: 'x' }
+    ];
+
+    // Translation has an extra placeholder not in source
+    const translation = [
+      { v: '{1}', t: 'x' },
+      { v: '{99}', t: 'x' },  // Not in source
+      { v: '{0}', t: 'x' }
+    ];
+
+    const indices = mapTranslationPlaceholdersToSource(source, translation);
+    // {1} maps to 1, {99} falls back to position (1), {0} maps to 0
+    assert.deepEqual(indices, [1, 1, 0]);
+    assert.deepEqual(getDisplayNumbers(indices), [2, 2, 1]);
+  });
+
+  test('handles duplicate tags with different types correctly', () => {
+    const source = [
+      { v: 'span', t: 'bx' },  // Opening span
+      { v: 'span', t: 'ex' },  // Closing span
+      { v: 'span', t: 'bx' },  // Another opening span
+      { v: 'span', t: 'ex' }   // Another closing span
+    ];
+
+    const translation = [
+      { v: 'span', t: 'bx' },  // Should map to first opening (0)
+      { v: 'span', t: 'bx' },  // Should map to second opening (2)
+      { v: 'span', t: 'ex' },  // Should map to first closing (1)
+      { v: 'span', t: 'ex' }   // Should map to second closing (3)
+    ];
+
+    const indices = mapTranslationPlaceholdersToSource(source, translation);
+    assert.deepEqual(indices, [0, 2, 1, 3]);
+    assert.deepEqual(getDisplayNumbers(indices), [1, 3, 2, 4]);
+  });
+
+  test('preserves order when translation matches source exactly', () => {
+    const source = [
+      { v: 'a', t: 'x' },
+      { v: 'b', t: 'x' },
+      { v: 'c', t: 'x' },
+      { v: 'd', t: 'x' }
+    ];
+
+    const translation = [
+      { v: 'a', t: 'x' },
+      { v: 'b', t: 'x' },
+      { v: 'c', t: 'x' },
+      { v: 'd', t: 'x' }
+    ];
+
+    const indices = mapTranslationPlaceholdersToSource(source, translation);
+    assert.deepEqual(indices, [0, 1, 2, 3]);
+    assert.deepEqual(getDisplayNumbers(indices), [1, 2, 3, 4]);
+  });
+
+  test('handles completely reversed translation', () => {
+    const source = [
+      { v: 'first', t: 'x' },
+      { v: 'second', t: 'x' },
+      { v: 'third', t: 'x' }
+    ];
+
+    const translation = [
+      { v: 'third', t: 'x' },
+      { v: 'second', t: 'x' },
+      { v: 'first', t: 'x' }
+    ];
+
+    const indices = mapTranslationPlaceholdersToSource(source, translation);
+    assert.deepEqual(indices, [2, 1, 0]);
+    assert.deepEqual(getDisplayNumbers(indices), [3, 2, 1]);
+  });
+});
+
+describe('Real-world Scenarios', () => {
+  test('flight delay notification', () => {
+    const source = [
+      "We've detected a delay of more than ",
+      { v: '{0}', t: 'x', s: '2' },
+      " hours for your flight from ",
+      { v: '{1}', t: 'x', s: 'Mexico City' },
+      " to ",
+      { v: '{2}', t: 'x', s: 'Monterrey' },
+      "."
+    ];
+
+    const translation = [
+      "เราตรวจพบว่าเที่ยวบินของคุณจาก ",
+      { v: '{1}', t: 'x', s: 'Mexico City' },
+      " ไปยัง ",
+      { v: '{2}', t: 'x', s: 'Monterrey' },
+      " ล่าช้ากว่า ",
+      { v: '{0}', t: 'x', s: '2' },
+      " ชั่วโมง"
+    ];
+
+    const indices = mapTranslationPlaceholdersToSource(source, translation);
+    // {1} is at index 1, {2} at index 2, {0} at index 0 in source
+    assert.deepEqual(indices, [1, 2, 0]);
+    assert.deepEqual(getDisplayNumbers(indices), [2, 3, 1]);
+  });
+
+  test('HTML content with multiple formatting tags', () => {
+    const source = [
+      "This is ",
+      { v: '<b>', t: 'bx' },
+      "bold and ",
+      { v: '<i>', t: 'bx' },
+      "italic",
+      { v: '</i>', t: 'ex' },
+      { v: '</b>', t: 'ex' },
+      " text with ",
+      { v: '<u>', t: 'bx' },
+      "underline",
+      { v: '</u>', t: 'ex' },
+      "."
+    ];
+
+    // Translation with reordered tags
+    const translation = [
+      "Questo è testo ",
+      { v: '<u>', t: 'bx' },
+      "sottolineato",
+      { v: '</u>', t: 'ex' },
+      " e ",
+      { v: '<b>', t: 'bx' },
+      { v: '<i>', t: 'bx' },
+      "corsivo grassetto",
+      { v: '</i>', t: 'ex' },
+      { v: '</b>', t: 'ex' },
+      "."
+    ];
+
+    const indices = mapTranslationPlaceholdersToSource(source, translation);
+    // Source positions: <b>=0, <i>=1, </i>=2, </b>=3, <u>=4, </u>=5
+    // Translation order: <u>=4, </u>=5, <b>=0, <i>=1, </i>=2, </b>=3
+    assert.deepEqual(indices, [4, 5, 0, 1, 2, 3]);
+    assert.deepEqual(getDisplayNumbers(indices), [5, 6, 1, 2, 3, 4]);
+  });
+
+  test('complex nested tags with duplicates', () => {
+    const source = [
+      { v: '<p>', t: 'bx' },
+      { v: '<b>', t: 'bx' },
+      { v: '</b>', t: 'ex' },
+      { v: '<b>', t: 'bx' },
+      { v: '</b>', t: 'ex' },
+      { v: '</p>', t: 'ex' }
+    ];
+
+    const translation = [
+      { v: '<p>', t: 'bx' },
+      { v: '<b>', t: 'bx' },
+      { v: '<b>', t: 'bx' },
+      { v: '</b>', t: 'ex' },
+      { v: '</b>', t: 'ex' },
+      { v: '</p>', t: 'ex' }
+    ];
+
+    const indices = mapTranslationPlaceholdersToSource(source, translation);
+    // <p>=0, first <b>=1, second <b>=3, first </b>=2, second </b>=4, </p>=5
+    assert.deepEqual(indices, [0, 1, 3, 2, 4, 5]);
+    assert.deepEqual(getDisplayNumbers(indices), [1, 2, 4, 3, 5, 6]);
+  });
+});
+
+describe('Edge Cases', () => {
+  test('empty source and translation', () => {
+    const indices = mapTranslationPlaceholdersToSource([], []);
+    assert.deepEqual(indices, []);
+    assert.deepEqual(getDisplayNumbers(indices), []);
+  });
+
+  test('only text content, no placeholders', () => {
+    const source = ['Hello world'];
+    const translation = ['Bonjour le monde'];
+
+    const indices = mapTranslationPlaceholdersToSource(source, translation);
+    assert.deepEqual(indices, []);
+    assert.deepEqual(getDisplayNumbers(indices), []);
+  });
+
+  test('source has placeholders but translation has none', () => {
+    const source = [
+      'Text ',
+      { v: '{0}', t: 'x' },
+      ' more'
+    ];
+    const translation = ['Translated text'];
+
+    const indices = mapTranslationPlaceholdersToSource(source, translation);
+    assert.deepEqual(indices, []);
+    assert.deepEqual(getDisplayNumbers(indices), []);
+  });
+
+  test('translation has placeholders but source has none', () => {
+    const source = ['Plain text'];
+    const translation = [
+      'Text ',
+      { v: '{0}', t: 'x' },
+      ' added'
+    ];
+
+    const indices = mapTranslationPlaceholdersToSource(source, translation);
+    // Falls back to position-based indexing
+    assert.deepEqual(indices, [0]);
+    assert.deepEqual(getDisplayNumbers(indices), [1]);
+  });
+});


### PR DESCRIPTION
Fixes to ensure
- source placeholder ids are based on the index of the order of the placeholder plus one.  translations placeholder ids should be in reference to the source placeholder ids.
- the placeholder ids should be based on source order, not the value of v, since not all placeholders have the order in the value of v
- account for duplicate placeholders  (for example multiple `<b>`)
- allow for drag and drop reordering of translation placeholders 